### PR TITLE
Document new local mods folder

### DIFF
--- a/docs/fundamentals/directories-and-files.md
+++ b/docs/fundamentals/directories-and-files.md
@@ -20,10 +20,12 @@ Where all the game assets live:
 - **KSA.dll** - Main game code (decompile with ILSpy)
 - **Brutal.dll** - Engine code
 
-## Logs and Saves Directory
+## User Data Directory
 
 **Location:** `C:\Users\[YourName]\Documents\My Games\Kitten Space Agency\`
 
 - **Logs** - `Brutal.log` and archived logs
 - **Saves** - Save game files
+- **mods/** - Local mods folder. Mods placed here are auto-discovered by the game and persist across game updates. See [Installing Mods](/KSAModding/getting-started/installing-mods/) for details.
+- **manifest.toml** - The local mod manifest that controls which mods are enabled.
  

--- a/docs/getting-started/installing-mods.md
+++ b/docs/getting-started/installing-mods.md
@@ -19,15 +19,13 @@ First make sure you installed StarMap via this guide: [StarMap installation guid
         └── StarMap.ExampleMod.dll
         └── ...
     ```
-3. Put this folder inside of the game content files: `"KSAInstallLocation/Content/`, This folder should also contain the `Core` mod folder.
-4. Lastly the mod needs to be added to the manifest.toml in the `"KSAInstallLocation"/Content/` folder, the id needs to match the name of the folder, the .dll file, the name variable inside mod.toml.
+3. Put this folder in one of the two supported mod locations:
+    - **Local mods folder (recommended):** `Documents\My Games\Kitten Space Agency\mods\` - Mods here persist across game updates.
+    - **Game content folder:** `KSAInstallLocation\Content\` - This folder also contains the `Core` mod folder. Mods here may be lost when the game updates.
+4. The game auto-discovers new mods and prompts you to enable them on startup. Alternatively, you can manually edit the `manifest.toml` in `Documents\My Games\Kitten Space Agency\` to enable or disable mods. The id must match the folder name:
 ```
 [[mods]]
-id= "core"
-enabled = true
-
-[[mods]]
-id = "[mod name]"
+id = "[mod folder name]"
 enabled = true
 ```
 5. When now loading the game via `StarMap.exe` or `StarMapLoader.exe`, the mod should be loaded and run.


### PR DESCRIPTION
Closes #16

Documents the local mods folder (`Documents/My Games/Kitten Space Agency/mods/`) introduced in v2026.2.34.3656 and the auto-discovery feature.

## Changes
- Added both mod locations (local mods folder + Content/) to the "installing mods" section, documented auto-discovery, kept manual manifest editing as alternative
- Renamed "Logs and Saves Directory" to "User Data Directory" since it also now contains the mods/ folder and manifest.toml

## Note
This PR depends on [StarMap#64](https://github.com/StarMapLoader/StarMap/issues/64) until once StarMap supports the local mods folder, so the guide doesn't recommend a path that StarMap can't load from yet.

**Tested against:** KSA v2026.2.34.3656